### PR TITLE
modified_item_create_action

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,5 +1,5 @@
 class Item < ApplicationRecord
-  belongs_to :buyer, class_name: 'User', :foreign_key => 'buyer_id'
+  belongs_to :buyer, class_name: 'User', :foreign_key => 'buyer_id', optional: true
   belongs_to :seller, class_name: 'User', :foreign_key => 'seller_id'
 
 


### PR DESCRIPTION
# what
buyer_id カラムのバリデーションを外した

# why
ユーザー登録時にエラーが出る為