### PR TITLE
exhibit_error_message

### DIFF
--- a/app/assets/javascripts/item-new.js
+++ b/app/assets/javascripts/item-new.js
@@ -9,7 +9,7 @@ $(function(){
         <p class="require-text">必須</p>
       </div>
       <div class="exhibit-box__main__delivery__methodbox__form">
-        <select class="item-select-form" name="item[delivery_method_id]" id="item_delivery_method_id"><option value="">選択してください</option>
+        <select class="item-select-form" name="item[delivery_method_id]" id="item_delivery_method_id" required><option value="">選択してください</option>
           <option value="1">未定</option>
           <option value="2">らくらくFURIMA便</option>
           <option value="3">ゆうメール</option>
@@ -29,7 +29,7 @@ $(function(){
         <p class="require-text">必須</p>
       </div>
       <div class="exhibit-box__main__delivery__methodbox__form">
-        <select class="item-select-form" name="item[delivery_method_id]" id="item_delivery_method_id"><option value="">選択してください</option>
+        <select class="item-select-form" name="item[delivery_method_id]" id="item_delivery_method_id" required><option value="">選択してください</option>
           <option value="1">未定</option>
           <option value="2">シロネコヤマト</option>
           <option value="3">ゆうメール</option>

--- a/app/assets/stylesheets/modules/exhibit.scss
+++ b/app/assets/stylesheets/modules/exhibit.scss
@@ -24,7 +24,17 @@
       width: 100%;
       height: 50px;
       background-color: white;
+      &:valid {
+        border: 1px solid lightslategray;
+      }
+      &:invalid {
+        border: 1px solid lightslategray;
+      }
       &:focus {
+        border: 2px solid $main-color;
+        outline: 0;
+      }
+      &:hover {
         border: 2px solid $main-color;
         outline: 0;
       }
@@ -48,21 +58,6 @@
         width: 100%;
         display: flex;
         margin-top: 30px;
-        .form-area-image {
-          width: 100%;
-          padding: 60px 15px;
-          border-radius: 4px;
-          border-width: 1px;
-          border-style: dashed;
-          border-color: rgb(204, 204, 204);
-          &:focus {
-            border: 2px solid $main-color;
-            outline: 0;
-          }
-          .upload-message {
-            color: lightslategray;
-          }
-        }
       }
     }
     &__content {
@@ -80,7 +75,17 @@
             padding: 15px;
             border-radius: 4px;
             border: 1px solid lightslategray;
+            &:valid {
+              border: 1px solid lightslategray;
+            }
+            &:invalid {
+              border: 1px solid lightslategray;
+            }
             &:focus {
+              border: 2px solid $main-color;
+              outline: 0;
+            }
+            &:hover {
               border: 2px solid $main-color;
               outline: 0;
             }
@@ -90,7 +95,17 @@
             padding: 60px 15px;
             border-radius: 4px;
             border: 1px solid lightslategray;
+            &:valid {
+              border: 1px solid lightslategray;
+            }
+            &:invalid {
+              border: 1px solid lightslategray;
+            }
             &:focus {
+              border: 2px solid $main-color;
+              outline: 0;
+            }
+            &:hover {
               border: 2px solid $main-color;
               outline: 0;
             }
@@ -129,7 +144,17 @@
             padding: 15px;
             border-radius: 4px;
             border: 1px solid lightslategray;
+            &:valid {
+              border: 1px solid lightslategray;
+            }
+            &:invalid {
+              border: 1px solid lightslategray;
+            }
             &:focus {
+              border: 2px solid $main-color;
+              outline: 0;
+            }
+            &:hover {
               border: 2px solid $main-color;
               outline: 0;
             }
@@ -241,7 +266,17 @@
           margin-left: 185px;
           text-align: right;
           border: 1px solid lightslategray;
+          &:valid {
+            border: 1px solid lightslategray;
+          }
+          &:invalid {
+            border: 1px solid lightslategray;
+          }
           &:focus {
+            border: 2px solid $main-color;
+            outline: 0;
+          }
+          &:hover {
             border: 2px solid $main-color;
             outline: 0;
           }
@@ -428,4 +463,8 @@
   text-align: center;
   border: 1px solid;
   border-radius: 5px;
+}
+
+.top-image-form {
+  width: 0.5px;
 }

--- a/app/assets/stylesheets/modules/exhibit.scss
+++ b/app/assets/stylesheets/modules/exhibit.scss
@@ -392,12 +392,6 @@
 }
 
 .form-color {
-  // &:valid {
-  //   border: 1px solid lightslategray;
-  // }
-  // &:invalid {
-  //   border: 1px solid lightslategray;
-  // }
   &:focus {
     border: 2px solid $main-color;
     outline: 0;

--- a/app/assets/stylesheets/modules/exhibit.scss
+++ b/app/assets/stylesheets/modules/exhibit.scss
@@ -24,20 +24,6 @@
       width: 100%;
       height: 50px;
       background-color: white;
-      &:valid {
-        border: 1px solid lightslategray;
-      }
-      &:invalid {
-        border: 1px solid lightslategray;
-      }
-      &:focus {
-        border: 2px solid $main-color;
-        outline: 0;
-      }
-      &:hover {
-        border: 2px solid $main-color;
-        outline: 0;
-      }
     }
     &__image {
       background-color: white;
@@ -75,40 +61,12 @@
             padding: 15px;
             border-radius: 4px;
             border: 1px solid lightslategray;
-            &:valid {
-              border: 1px solid lightslategray;
-            }
-            &:invalid {
-              border: 1px solid lightslategray;
-            }
-            &:focus {
-              border: 2px solid $main-color;
-              outline: 0;
-            }
-            &:hover {
-              border: 2px solid $main-color;
-              outline: 0;
-            }
           }
           .form-area-description {
             width: 100%;
             padding: 60px 15px;
             border-radius: 4px;
             border: 1px solid lightslategray;
-            &:valid {
-              border: 1px solid lightslategray;
-            }
-            &:invalid {
-              border: 1px solid lightslategray;
-            }
-            &:focus {
-              border: 2px solid $main-color;
-              outline: 0;
-            }
-            &:hover {
-              border: 2px solid $main-color;
-              outline: 0;
-            }
           }
         }
       }
@@ -144,20 +102,6 @@
             padding: 15px;
             border-radius: 4px;
             border: 1px solid lightslategray;
-            &:valid {
-              border: 1px solid lightslategray;
-            }
-            &:invalid {
-              border: 1px solid lightslategray;
-            }
-            &:focus {
-              border: 2px solid $main-color;
-              outline: 0;
-            }
-            &:hover {
-              border: 2px solid $main-color;
-              outline: 0;
-            }
           }
         }
       }
@@ -266,20 +210,6 @@
           margin-left: 185px;
           text-align: right;
           border: 1px solid lightslategray;
-          &:valid {
-            border: 1px solid lightslategray;
-          }
-          &:invalid {
-            border: 1px solid lightslategray;
-          }
-          &:focus {
-            border: 2px solid $main-color;
-            outline: 0;
-          }
-          &:hover {
-            border: 2px solid $main-color;
-            outline: 0;
-          }
         }
         .bold-text-price {
           margin: 10px 0px 0px 7px;
@@ -448,17 +378,9 @@
   }
 }
 
-.mask {
-  display: none;
-}
-
-
 #image-box {
   width: 100%;
   height: 300px;
-  // display: flex;
-  // justify-content: center;
-  // align-items: center;
   background-color: lightgray;
   text-align: center;
   border: 1px solid;
@@ -467,4 +389,21 @@
 
 .top-image-form {
   width: 0.5px;
+}
+
+.form-color {
+  // &:valid {
+  //   border: 1px solid lightslategray;
+  // }
+  // &:invalid {
+  //   border: 1px solid lightslategray;
+  // }
+  &:focus {
+    border: 2px solid $main-color;
+    outline: 0;
+  }
+  &:hover {
+    border: 2px solid $main-color;
+    outline: 0;
+  }
 }

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -24,7 +24,7 @@
               
                   .input-area
                     .js-file_group{data: {index: "#{image.index}"}, type: "file"} 
-                      = image.file_field :image, style: "display:none", id:"img-file", class: 'js-file'
+                      = image.file_field :image, id:"img-file", class: 'js-file top-image-form', required: ""
                       %label{for: "img-file"}
                         %i.fas.fa-camera
                       %br
@@ -52,13 +52,14 @@
             %h3.bold-text 商品名
             %p.require-text 必須
           .exhibit-box__main__content__namebox__form
-            = f.text_field :title, placeholder: "40文字まで", maxlength: "40", class: "form-area-name"
+            = f.text_field :title,placeholder: "40文字まで", maxlength: "40", required: "", class: "form-area-name"
+
         .exhibit-box__main__content__namebox
           .exhibit-box__main__content__namebox__text
             %h3.bold-text 商品の説明
             %p.require-text 必須
           .exhibit-box__main__content__namebox__form
-            = f.text_area :text, placeholder: "1,000文字まで（色、素材、重さ、定価、注意点など）", maxlength: "1000", class: "form-area-description"
+            = f.text_area :text, placeholder: "1,000文字まで（色、素材、重さ、定価、注意点など）", maxlength: "1000", required: "", class: "form-area-description"
 
       .exhibit-box__main__details
         .exhibit-box__main__details__categorybox
@@ -67,8 +68,7 @@
             %h3.bold-text カテゴリー
             %p.require-text 必須
           .exhibit-box__main__details__categorybox__form
-            = f.select :category_id, [], {}, class: "item-select-form" do
-              %option{ value: ""} 選択してください
+            = f.select :category_id, [], {prompt: "選択してください"}, class: "item-select-form", required: "" do
               %option{ value: "1"} レディース
               %option{ value: "2"} メンズ
               %option{ value: "3"} ベビー・キッズ
@@ -93,8 +93,7 @@
             %h3.bold-text 商品の状態
             %p.require-text 必須
           .exhibit-box__main__details__statusbox__form
-            = f.select :status, [], {}, class: "item-select-form" do
-              %option{ value: ""} 選択してください
+            = f.select :status, [], {prompt: "選択してください"}, class: "item-select-form", required: "" do
               %option{ value: "1"} 新品、未使用
               %option{ value: "2"} 未使用に近い
               %option{ value: "3"} 目立った傷や汚れなし
@@ -109,7 +108,7 @@
             %h3.bold-text 配送料の負担
             %p.require-text 必須
           .exhibit-box__main__delivery__chargebox__form
-          = f.collection_select :delivery_charge_id, DeliveryCharge.all, :id, :charge, {prompt: "選択してください"}, class: "item-select-form"
+          = f.collection_select :delivery_charge_id, DeliveryCharge.all, :id, :charge, {prompt: "選択してください"}, class: "item-select-form", required: ""
         .exhibit-box__main__delivery__methodbox.delivery-method-area
           -# ------------------------jQueryにて挿入される部分------------------------------------
         .exhibit-box__main__delivery__originbox
@@ -117,14 +116,13 @@
             %h3.bold-text 配送元の地域
             %p.require-text 必須
           .exhibit-box__main__delivery__originbox__form
-            = f.collection_select :delivery_origin_id, DeliveryOrigin.all, :id, :name, {prompt: "選択してください"}, class: "item-select-form"
+            = f.collection_select :delivery_origin_id, DeliveryOrigin.all, :id, :name, {prompt: "選択してください"}, class: "item-select-form", required: ""
         .exhibit-box__main__delivery__sizebox
           .exhibit-box__main__delivery__sizebox__text
             %h3.bold-text 配送物のサイズ
             %p.require-text 必須
           .exhibit-box__main__delivery__sizebox__form
-            = f.select :delivery_size, [], {}, class: "item-select-form" do
-              %option{ value: ""} 選択してください
+            = f.select :delivery_size, [], {prompt: "選択してください"}, class: "item-select-form", required: ""  do
               %option{ value: "1"} ネコポス（A4サイズ・厚さ2.5cm以内）
               %option{ value: "2"} 宅急便コンパクト
               %option{ value: "3"} 宅急便（60~160サイズ）
@@ -133,8 +131,7 @@
             %h3.bold-text 配送までの日数
             %p.require-text 必須
           .exhibit-box__main__delivery__delivery-days-box__form
-            = f.select :delivery_days, [], {}, class: "item-select-form" do
-              %option{ value: ""} 選択してください
+            = f.select :delivery_days, [], {prompt: "選択してください"}, class: "item-select-form", required: ""  do
               %option{ value: "1"} 1~2日で発送
               %option{ value: "2"} 2~3日で発送
               %option{ value: "3"} 4~7日で発送
@@ -146,7 +143,7 @@
           %h3.bold-text-price 販売価格
           %p.require-text-price 必須
           %p.dollar-mark￥
-          = f.text_field :price, placeholder: "0", class: "form-area-price"
+          = f.text_field :price, placeholder: "0", class: "form-area-price", required: "", max:"9999999", min: "300", type:"number"
         .exhibit-box__main__under__commission
           %h4.price-commission 販売手数料 (10%)
           %p.simple-hyphen-up ---

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -52,14 +52,14 @@
             %h3.bold-text 商品名
             %p.require-text 必須
           .exhibit-box__main__content__namebox__form
-            = f.text_field :title,placeholder: "40文字まで", maxlength: "40", required: "", class: "form-area-name"
+            = f.text_field :title,placeholder: "40文字まで", maxlength: "40", required: "", class: "form-area-name form-color"
 
         .exhibit-box__main__content__namebox
           .exhibit-box__main__content__namebox__text
             %h3.bold-text 商品の説明
             %p.require-text 必須
           .exhibit-box__main__content__namebox__form
-            = f.text_area :text, placeholder: "1,000文字まで（色、素材、重さ、定価、注意点など）", maxlength: "1000", required: "", class: "form-area-description"
+            = f.text_area :text, placeholder: "1,000文字まで（色、素材、重さ、定価、注意点など）", maxlength: "1000", required: "", class: "form-area-description form-color"
 
       .exhibit-box__main__details
         .exhibit-box__main__details__categorybox
@@ -68,7 +68,7 @@
             %h3.bold-text カテゴリー
             %p.require-text 必須
           .exhibit-box__main__details__categorybox__form
-            = f.select :category_id, [], {prompt: "選択してください"}, class: "item-select-form", required: "" do
+            = f.select :category_id, [], {prompt: "選択してください"}, class: "item-select-form form-color", required: "" do
               %option{ value: "1"} レディース
               %option{ value: "2"} メンズ
               %option{ value: "3"} ベビー・キッズ
@@ -87,13 +87,13 @@
             %h3.bold-text ブランド
             %p.any-text 任意
           .exhibit-box__main__details__brandbox__form
-            = f.text_field :brand_id, placeholder: "例） NIKE", class: "form-area-brand"
+            = f.text_field :brand_id, placeholder: "例） NIKE", class: "form-area-brand form-color"
         .exhibit-box__main__details__statusbox
           .exhibit-box__main__details__statusbox__text
             %h3.bold-text 商品の状態
             %p.require-text 必須
           .exhibit-box__main__details__statusbox__form
-            = f.select :status, [], {prompt: "選択してください"}, class: "item-select-form", required: "" do
+            = f.select :status, [], {prompt: "選択してください"}, class: "item-select-form form-color", required: "" do
               %option{ value: "1"} 新品、未使用
               %option{ value: "2"} 未使用に近い
               %option{ value: "3"} 目立った傷や汚れなし
@@ -108,7 +108,7 @@
             %h3.bold-text 配送料の負担
             %p.require-text 必須
           .exhibit-box__main__delivery__chargebox__form
-          = f.collection_select :delivery_charge_id, DeliveryCharge.all, :id, :charge, {prompt: "選択してください"}, class: "item-select-form", required: ""
+          = f.collection_select :delivery_charge_id, DeliveryCharge.all, :id, :charge, {prompt: "選択してください"}, class: "item-select-form form-color", required: ""
         .exhibit-box__main__delivery__methodbox.delivery-method-area
           -# ------------------------jQueryにて挿入される部分------------------------------------
         .exhibit-box__main__delivery__originbox
@@ -116,13 +116,13 @@
             %h3.bold-text 配送元の地域
             %p.require-text 必須
           .exhibit-box__main__delivery__originbox__form
-            = f.collection_select :delivery_origin_id, DeliveryOrigin.all, :id, :name, {prompt: "選択してください"}, class: "item-select-form", required: ""
+            = f.collection_select :delivery_origin_id, DeliveryOrigin.all, :id, :name, {prompt: "選択してください"}, class: "item-select-form form-color", required: ""
         .exhibit-box__main__delivery__sizebox
           .exhibit-box__main__delivery__sizebox__text
             %h3.bold-text 配送物のサイズ
             %p.require-text 必須
           .exhibit-box__main__delivery__sizebox__form
-            = f.select :delivery_size, [], {prompt: "選択してください"}, class: "item-select-form", required: ""  do
+            = f.select :delivery_size, [], {prompt: "選択してください"}, class: "item-select-form form-color", required: ""  do
               %option{ value: "1"} ネコポス（A4サイズ・厚さ2.5cm以内）
               %option{ value: "2"} 宅急便コンパクト
               %option{ value: "3"} 宅急便（60~160サイズ）
@@ -131,7 +131,7 @@
             %h3.bold-text 配送までの日数
             %p.require-text 必須
           .exhibit-box__main__delivery__delivery-days-box__form
-            = f.select :delivery_days, [], {prompt: "選択してください"}, class: "item-select-form", required: ""  do
+            = f.select :delivery_days, [], {prompt: "選択してください"}, class: "item-select-form form-color", required: ""  do
               %option{ value: "1"} 1~2日で発送
               %option{ value: "2"} 2~3日で発送
               %option{ value: "3"} 4~7日で発送
@@ -143,7 +143,7 @@
           %h3.bold-text-price 販売価格
           %p.require-text-price 必須
           %p.dollar-mark￥
-          = f.text_field :price, placeholder: "0", class: "form-area-price", required: "", max:"9999999", min: "300", type:"number"
+          = f.text_field :price, placeholder: "0", class: "form-area-price form-color", required: "", max:"9999999", min: "300", type:"number"
         .exhibit-box__main__under__commission
           %h4.price-commission 販売手数料 (10%)
           %p.simple-hyphen-up ---


### PR DESCRIPTION
# what
商品新規投稿画面の入力内容が相応しくない場合のエラー内容の表示のみ実装

# why
入力漏れを防ぐため。

画像が０枚の時のエラー表示↓
https://gyazo.com/f9fd936a5331557cba0d442efbdfc6df

active hashの分の配送の方法が選択されていない時のエラー表示↓
https://gyazo.com/fb6d7a76efef9d2aa647579bc4ff68ac


テストはまだです。