### PR TITLE
create_delete_edit_button

### DIFF
--- a/app/assets/stylesheets/modules/_top.scss
+++ b/app/assets/stylesheets/modules/_top.scss
@@ -494,3 +494,16 @@ header {
     opacity: 0.9;
   }
 }
+
+.edit-icon {
+  background-color: lightsalmon;
+  bottom: 160px;
+}
+.delete-icon {
+  background-color: red;
+  bottom: 32px;
+}
+.icon-size {
+  font-size: 62px;
+  color: white;
+}

--- a/app/views/items/_delete-edit-icon.html.haml
+++ b/app/views/items/_delete-edit-icon.html.haml
@@ -1,0 +1,20 @@
+- if signed_in?
+  - if current_user.id == @item.seller_id
+    = link_to edit_item_path, class: "push-icon edit-icon" do
+      %span.push-icon__text
+        編集する
+      %i.fas.fa-edit{class: "icon-size"}
+    = link_to item_path, method: :delete, class: "push-icon delete-icon" do
+      %span.push-icon__text
+        削除する
+      %i.fas.fa-trash-alt{class: "icon-size"}
+  - else
+    = link_to new_item_path, class: "push-icon" do
+      %span.push-icon__text
+        出品する
+      = image_tag asset_path('icon/icon_camera.png'), class: 'camera-icon'
+- else 
+  = link_to new_user_session_path, class: "push-icon" do
+    %span.push-icon__text
+      出品する
+    = image_tag asset_path('icon/icon_camera.png'), class: 'camera-icon'

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -1,3 +1,3 @@
 編集画面
 
-= link_to "戻る", item_path(@items.id)
+= link_to "戻る", :back

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -170,4 +170,4 @@
   = render "fourth-index"
   = render "footer"
 
-= render "push-icon"
+= render "delete-edit-icon.html", locals: {item: @item}


### PR DESCRIPTION
# what
詳細ページで投稿したユーザーのみ
編集、削除ボタンを表示
編集ボタンで編集画面へ遷移
削除ボタンで商品を削除できる

# why
商品編集、削除に必要だから

# gif
編集　https://gyazo.com/29ba9ad79f4f4e3ad1d73653e770dc6f
削除　https://gyazo.com/f0215fa9e5df04617323049d79f11b0f